### PR TITLE
User fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "webdevstudios/cmb2-attached-posts",
+    "name": "spencerm/cmb2-attached-posts",
     "description": "Custom field for CMB2 for creating post relationships.",
     "license": "GPL-2.0+",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -2,25 +2,8 @@
     "name": "spencerm/cmb2-attached-posts",
     "description": "Custom field for CMB2 for creating post relationships.",
     "license": "GPL-2.0+",
-    "authors": [
-        {
-            "name": "WebDevStudios",
-            "email": "contact@webdevstudios.com",
-            "homepage": "https://github.com/WebDevStudios",
-            "role": "Developer"
-        }
-    ],
-    "keywords": ["wordpress", "plugin", "metabox","post","relationship","attached"],
-    "homepage": "https://github.com/WebDevStudios/CMB2",
     "type": "wordpress-plugin",
-    "support": {
-        "issues": "https://github.com/WebDevStudios/cmb2-attached-posts/issues",
-        "source": "https://github.com/WebDevStudios/cmb2-attached-posts/"
-    },
     "require": {
         "php": ">5.2.4"
-    },
-    "suggest": {
-        "composer/installers": "~1.0"
     }
 }

--- a/init.php
+++ b/init.php
@@ -112,7 +112,7 @@ class WDS_CMB2_Attached_Posts_Field {
 		} else {
 			// Setup our args
 			$args = wp_parse_args( $query_args, array(
-				'number' => 100,
+				'number' => -1,
 			) );
 			$post_type_labels = $field_type->_text( 'users_text', esc_html__( 'Users' ) );
 		}


### PR DESCRIPTION
When using query_users, neither `number` nor `number_of_posts` are passed into the query, meaning it's impossible to to query more than 100 users. 

There's probably a better solution than this, but this does work.