### PR TITLE
add filter to give us more control over get_all_objects()

### DIFF
--- a/init.php
+++ b/init.php
@@ -430,7 +430,8 @@ class WDS_CMB2_Attached_Posts_Field {
 			}
 		}
 
-		return $attached_objects;
+		return apply_filters( 'cmb2_attached_posts_objects', $attached_objects, $args );
+
 	}
 
 	/**


### PR DESCRIPTION
Due to the way our in-house framework is built, we have some special objects that we sometimes want to add (outside of a custom post type). Adding a filter here will allow us to do it without hardcoding it. It should also be good all-around to give a bit more control to devs.