### PR TITLE
Update attached-posts-admin.css

### DIFF
--- a/css/attached-posts-admin.css
+++ b/css/attached-posts-admin.css
@@ -39,7 +39,8 @@
 }
 
 .cmb-type-custom-attached-posts .has-thumbnails.connected {
-	height: 30em;
+	height: 150px;
+	overflow: scroll;
 }
 
 .cmb-type-custom-attached-posts .has-thumbnails li {


### PR DESCRIPTION
This is a proposal :)
The gray columns, seem to me really big compared to the rest of the other fields.  With this little modification, I find this configuration more user-friendly.

<img width="933" alt="Capture d’écran 2022-05-18 à 22 56 32" src="https://user-images.githubusercontent.com/74772189/169154376-17337111-c547-4f75-b385-0bd505f376e4.png">

